### PR TITLE
Since the length of a Tweet is now 280 characters, we should double t…

### DIFF
--- a/src/ShareableLink.php
+++ b/src/ShareableLink.php
@@ -65,7 +65,7 @@ class ShareableLink
     {
         return $this->buildFormattedUrl('https://twitter.com/intent/tweet?', [
             'url' => $this->url,
-            'text' => urlencode($this->limit($this->title, 120)),
+            'text' => urlencode($this->limit($this->title, 240)),
         ]);
     }
 


### PR DESCRIPTION
…he max length of text in Twitter link to 240 characters.